### PR TITLE
Fix dingux compilation name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,7 +173,7 @@ libretro-build-ios9:
 
 ################################### CONSOLES #################################
 # Dingux (GCW Zero)
-libretro-build-dingux:
+libretro-build-dingux-mips32:
   extends:
     - .libretro-dingux-mips32-make-default
     - .core-defs


### PR DESCRIPTION
Packaging relies on specific names of the compilations. Fix it for dingux