### PR TITLE
Fix dingux name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,7 +173,7 @@ libretro-build-ios9:
 
 ################################### CONSOLES #################################
 # Dingux (GCW Zero)
-libretro-build-dingux:
+libretro-build-dingux-mips32:
   extends:
     - .libretro-dingux-mips32-make-default
     - .core-defs


### PR DESCRIPTION
dingux uses wrong name and so isn't picked up by packaging stage

Describe what your pull request does...

Place here why it should be merged, if applicable...

In order to make a contribution, you must agree to the contributor agreement:

```
You grant Stephanie Gawroriski an irrevocable license that:

 1. That you own the contributing work.
```

Owned by my employer Google but I'm allowed to release it and to grant rights to redistribute, translate and so on as per Google open source policy.

```
 3. Grants a patent license, as per the GNU GPLv3.
 4. Granting Stephanie Gawroriski permission to redistribute, sell, lease,
    modify, transform, translate, and relicense the specified works. This
    is to simplify the licensing of the project and permit it to be
    consistent. Your contribution may be commercially licensed to other
    parties supporting the project through this means.
 5. If employed by a company, you have a right by that company to provide
    contributions to this project.
 6. Have pledged to follow the Code of Conduct.
 7. Have read and understand the Ettiquite.
```

Choose one of the following:

 * I decline to accept the contributor agreement and wish to seek an
   alternative agreement.
 * I accept the contributor agreement.
 * This agreement is not applicable because this work is in the public
   domain (or CC0 license) or does not constitute something which can be
   copyrighted (single word changes, white-space changes, etc.).

Additionally, choose one of the following:

 * I decline to accept that SquirrelJME uses Fossil for its source control
   management and I do not understand that my pull request will be merged
   via patch in Fossil instead of via GitHub.
 * I accept that SquirrelJME uses Fossil for its source control
   management and I do understand that my pull request will be merged
   via patch in Fossil instead of via GitHub.
