### PR TITLE
use emar under emscripten instead of emcc for archive file

### DIFF
--- a/ratufacoat/makefilelibretro
+++ b/ratufacoat/makefilelibretro
@@ -425,6 +425,7 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_emscripten.bc
 	STATIC_LINKING = 1
+	AR = emar
 
 # GCW0
 else ifeq ($(platform), gcw0)
@@ -570,7 +571,7 @@ all: $(TARGET)
 $(TARGET): $(OBJECTS)
 	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) $(arch) **"
 ifeq ($(platform), emscripten)
-	$(CC) $(CFLAGS) $(OBJOUT)$@ $^
+	$(AR) rcs $@ $(OBJECTS)
 else ifeq ($(STATIC_LINKING_LINK), 1)
 ifneq (,$(findstring msvc,$(platform)))
 	$(LD) $(LINKOUT)$@ $(OBJECTS)


### PR DESCRIPTION
This PR fixes the build under newer versions of the Emscripten EMSDK, which prefer the use of `emar` for archive file creation (.bc files) instead of `emcc`.  Per the discussion in https://github.com/libretro/RetroArch/pull/15688.

```
You grant Stephanie Gawroriski an irrevocable license that:

 1. That you own the contributing work.
 2. Grants a patent license, as per the GNU GPLv3.
 3. Granting Stephanie Gawroriski permission to redistribute, sell, lease,
    modify, transform, translate, and relicense the specified works. This
    is to simplify the licensing of the project and permit it to be
    consistent. Your contribution may be commercially licensed to other
    parties supporting the project through this means.
 4. If employed by a company, you have a right by that company to provide
    contributions to this project.
 5. Have pledged to follow the Code of Conduct.
 6. Have read and understand the Ettiquite.
```

Choose one of the following:

 * I decline to accept the contributor agreement and wish to seek an
   alternative agreement.
 * I accept the contributor agreement.
 * [X] This agreement is not applicable because this work is in the public
   domain (or CC0 license) or does not constitute something which can be
   copyrighted (single word changes, white-space changes, etc.).

Additionally, choose one of the following:

 * I decline to accept that SquirrelJME uses Fossil for its source control
   management and I do not understand that my pull request will be merged
   via patch in Fossil instead of via GitHub.
 * [X] I accept that SquirrelJME uses Fossil for its source control
   management and I do understand that my pull request will be merged
   via patch in Fossil instead of via GitHub.
