### PR TITLE
scritchPencilRaster: Fix MIDP transformations

### DIFF
--- a/nanocoat/include/lib/scritchui/core/coreRaster.h
+++ b/nanocoat/include/lib/scritchui/core/coreRaster.h
@@ -123,6 +123,41 @@ sjme_errorCode sjme_scritchpen_coreUtil_applyAnchor(
 	sjme_attrOutNotNull sjme_jint* outX,
 	sjme_attrOutNotNull sjme_jint* outY);
 
+/**
+ * Applies coordinate adjustments based on the provided transformation, so
+ * that subsequent region manipulations are using the correct coordinates.
+ * 
+ * @param inTrans The transformation type.
+ * @param x The source region x position.
+ * @param y The source region y position.
+ * @param w The source region width.
+ * @param h The source region height.
+ * @param h The source height.
+ * @param dataWidth The width of the entire data/image.
+ * @param dataHeight The height of the entire data/image.
+ * @since 2025/12/01
+ */
+sjme_errorCode sjme_scritchpen_coreUtil_applyCoordinateAdj(
+	sjme_attrInValue sjme_scritchui_pencilTranslate inTrans,
+	sjme_attrInValue sjme_jint* x,
+	sjme_attrInValue sjme_jint* y,
+	sjme_attrInPositive sjme_jint* w,
+	sjme_attrInPositive sjme_jint* h,
+	sjme_attrInPositive sjme_jint dataWidth,
+	sjme_attrInPositive sjme_jint dataHeight);
+
+/**
+ * Applies rotation and scaling.
+ * 
+ * @param outMatrix The resultant matrix.
+ * @param inTrans The translation to use.
+ * @param wSrc The source width.
+ * @param hSrc The source height.
+ * @param wDest The destination width.
+ * @param hDest The destination height.
+ * @return Any resultant error, if any.
+ * @since 2024/07/12
+ */
 sjme_errorCode sjme_scritchpen_coreUtil_applyRotateScale(
 	sjme_attrOutNotNull sjme_scritchui_pencilMatrix* outMatrix,
 	sjme_attrInValue sjme_scritchui_pencilTranslate inTrans,

--- a/nanocoat/include/lib/scritchui/scritchuiPencil.h
+++ b/nanocoat/include/lib/scritchui/scritchuiPencil.h
@@ -225,6 +225,29 @@ typedef sjme_errorCode (*sjme_scritchui_pencilApplyAnchorFunc)(
 	sjme_attrOutNotNull sjme_jint* outY);
 
 /**
+ * Applies coordinate adjustments based on the provided transformation, so
+ * that subsequent region manipulations are using the correct coordinates.
+ * 
+ * @param inTrans The transformation type.
+ * @param x The source region x position.
+ * @param y The source region y position.
+ * @param w The source region width.
+ * @param h The source region height.
+ * @param h The source height.
+ * @param dataWidth The width of the entire data/image.
+ * @param dataHeight The height of the entire data/image.
+ * @since 2025/12/01
+ */
+typedef sjme_errorCode (*sjme_scritchui_pencilApplyCoordinateAdjFunc)(
+	sjme_attrInValue sjme_scritchui_pencilTranslate inTrans,
+	sjme_attrInValue sjme_jint* x,
+	sjme_attrInValue sjme_jint* y,
+	sjme_attrInPositive sjme_jint* w,
+	sjme_attrInPositive sjme_jint* h,
+	sjme_attrInPositive sjme_jint dataWidth,
+	sjme_attrInPositive sjme_jint dataHeight);
+
+/**
  * Applies rotation and scaling.
  * 
  * @param outMatrix The resultant matrix.
@@ -1046,6 +1069,9 @@ struct sjme_scritchui_pencilUtilFunctions
 	/** @c ApplyAnchor . */
 	SJME_SCRITCHUI_QUICK_PENCIL(ApplyAnchor, applyAnchor);
 	
+	/** @c ApplyCoordinateAdj . */
+	SJME_SCRITCHUI_QUICK_PENCIL(ApplyCoordinateAdj, applyCoordinateAdj);
+
 	/** @c ApplyRotateScale . */
 	SJME_SCRITCHUI_QUICK_PENCIL(ApplyRotateScale, applyRotateScale);
 	

--- a/nanocoat/lib/scritchui/scritchPencil.c
+++ b/nanocoat/lib/scritchui/scritchPencil.c
@@ -165,6 +165,7 @@ static const sjme_scritchui_pencilUtilFunctions
 {
 	sjme_sm(.blendRGBInto, sjme_scritchpen_coreUtil_blendRGBInto),
 	sjme_sm(.applyAnchor, sjme_scritchpen_coreUtil_applyAnchor),
+	sjme_sm(.applyCoordinateAdj, sjme_scritchpen_coreUtil_applyCoordinateAdj),
 	sjme_sm(.applyRotateScale, sjme_scritchpen_coreUtil_applyRotateScale),
 	sjme_sm(.applyTranslate, sjme_scritchpen_coreUtil_applyTranslate),
 	sjme_sm(.rawScanBytes, sjme_scritchpen_coreUtil_rawScanBytes),

--- a/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
+++ b/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
@@ -168,95 +168,14 @@ sjme_errorCode sjme_scritchpen_core_drawXRGB32Region(
 		&m, trans, wSrc, hSrc, wDest, hDest)))
 		return sjme_error_default(error);
 
-
 	/**
 	 * Now we need to adjust the source and destination areas to account for
 	 * the transformed image, otherwise we'll read from an incorrect area, and
 	 * draw to another wrong area.
 	 */
-
-	/**
-	 * Whenever we receive a transformation that alters the width and height
-	 * the image, the first adjustment we have to do is update the source and
-	 * destination width/height accordingly (makes source/dest width and height
-	 * usage more consistent on further adjustments and clipping).
-	 *
-	 * Once a case is matched, the adjustments are done and the code skips
-	 * directly to the anchoring setup, saving unnecessary if checks,
-	 * especially for the more common cases like TRANS_MIRROR.
-	 */
-	if(trans == SJME_SCRITCHUI_TRANS_ROT90 ||
-		trans == SJME_SCRITCHUI_TRANS_ROT270 ||
-		trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90 ||
-		trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
-	{
-		temp = hSrc;
-		hSrc = wSrc;
-		wSrc = temp;
-
-		temp = hDest;
-		hDest = wDest;
-		wDest = temp;
-	}
-
-	/* Mirrored horizontally */
-	if (trans == SJME_SCRITCHUI_TRANS_MIRROR)
-	{
-		xSrc = scanLen - xSrc - wSrc + 1;
-		goto anchor_setup;
-	}
-
-	/* Mirrored vertically */
-	if (trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT180)
-	{
-		ySrc = (dataLen / scanLen) - ySrc - hSrc + 1;
-		goto anchor_setup;
-	}
-
-	/* Was rotated 90 degrees clockwise. BROKEN */
-	if (trans == SJME_SCRITCHUI_TRANS_ROT90)
-	{
-		temp = xSrc;
-		xSrc = (dataLen / scanLen) - ySrc - wSrc + 1;
-		ySrc = temp;
-		goto anchor_setup;
-	}
-
-	/* Was mirrored horizontally and rotated 90 degrees clockwise.*/
-	if(trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90)
-	{
-		temp = ySrc;
-		ySrc = scanLen - xSrc - hSrc + 1;
-		xSrc = (dataLen / scanLen) - temp - wSrc + 1;
-		goto anchor_setup;
-	}
-
-	/* Was rotated 180 degrees clockwise. */
-	if (trans == SJME_SCRITCHUI_TRANS_ROT180)
-	{
-		xSrc = scanLen - xSrc - wSrc + 1;
-		ySrc = (dataLen / scanLen) - ySrc - hSrc + 1;
-		goto anchor_setup;
-	}
-
-	/* Was rotated 270 degrees clockwise */
-	if(trans == SJME_SCRITCHUI_TRANS_ROT270)
-	{
-		temp = ySrc;
-		ySrc = scanLen - xSrc - hSrc + 1;
-		xSrc = temp;
-		goto anchor_setup;
-	}
-
-	/* Was mirrored horizontally and rotated 270 degrees clockwise */
-	if(trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
-	{
-		temp = xSrc;
-		xSrc = ySrc;
-		ySrc = temp;
-	}
-
-anchor_setup:
+	if (sjme_error_is(error = sjme_scritchpen_coreUtil_applyCoordinateAdj(
+		trans, &xSrc, &ySrc, &wSrc, &hSrc, scanLen, (dataLen / scanLen))))
+		return sjme_error_default(error);
 	
 	/* Anchor to target coordinates after scaling, because we need */
 	/* to know what our target scale is. */

--- a/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
+++ b/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
@@ -18,7 +18,6 @@
 #include "sjme/fixed.h"
 
 static void sjme_scritchpen_core_clipLeftTop(
-	sjme_jint dim,
 	sjme_jint clipAt,
 	sjme_jint* zSrc,
 	sjme_jint* zDest,
@@ -131,7 +130,7 @@ sjme_errorCode sjme_scritchpen_core_drawXRGB32Region(
 	sjme_errorCode error;
 	sjme_scritchui_pencilMatrix m;
 	sjme_fixed wx, zy, wxBase, zyMajor;
-	sjme_jint dx, dy, iwx, izy, at;
+	sjme_jint dx, dy, iwx, izy, at, temp;
 	sjme_jint* srcRgb;
 	sjme_jint srcRgbBytes, srcAlphaMask;
 	sjme_jboolean srcAlpha, mulAlpha;
@@ -161,13 +160,103 @@ sjme_errorCode sjme_scritchpen_core_drawXRGB32Region(
 	
 	/* Translate base coordinates. */
 	sjme_scritchpen_coreUtil_applyTranslate(g, &xDest, &yDest);
-	
+
 	/* We are now doing the transforming and drawing ourselves. */
 	/* Calculate transformation matrix. */
 	memset(&m, 0, sizeof(m));
 	if (sjme_error_is(error = sjme_scritchpen_coreUtil_applyRotateScale(
 		&m, trans, wSrc, hSrc, wDest, hDest)))
 		return sjme_error_default(error);
+
+
+	/**
+	 * Now we need to adjust the source and destination areas to account for
+	 * the transformed image, otherwise we'll read from an incorrect area, and
+	 * draw to another wrong area.
+	 */
+
+	/**
+	 * Whenever we receive a transformation that alters the width and height
+	 * the image, the first adjustment we have to do is update the source and
+	 * destination width/height accordingly (makes source/dest width and height
+	 * usage more consistent on further adjustments and clipping).
+	 *
+	 * Once a case is matched, the adjustments are done and the code skips
+	 * directly to the anchoring setup, saving unnecessary if checks,
+	 * especially for the more common cases like TRANS_MIRROR.
+	 */
+	if(trans == SJME_SCRITCHUI_TRANS_ROT90 ||
+		trans == SJME_SCRITCHUI_TRANS_ROT270 ||
+		trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90 ||
+		trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
+	{
+		temp = hSrc;
+		hSrc = wSrc;
+		wSrc = temp;
+
+		temp = hDest;
+		hDest = wDest;
+		wDest = temp;
+	}
+
+	/* Mirrored horizontally */
+	if (trans == SJME_SCRITCHUI_TRANS_MIRROR)
+	{
+		xSrc = scanLen - xSrc - wSrc + 1;
+		goto anchor_setup;
+	}
+
+	/* Mirrored vertically */
+	if (trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT180)
+	{
+		ySrc = (dataLen / scanLen) - ySrc - hSrc + 1;
+		goto anchor_setup;
+	}
+
+	/* Was rotated 90 degrees clockwise. BROKEN */
+	if (trans == SJME_SCRITCHUI_TRANS_ROT90)
+	{
+		temp = xSrc;
+		xSrc = (dataLen / scanLen) - ySrc - wSrc + 1;
+		ySrc = temp;
+		goto anchor_setup;
+	}
+
+	/* Was mirrored horizontally and rotated 90 degrees clockwise.*/
+	if(trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90)
+	{
+		temp = ySrc;
+		ySrc = scanLen - xSrc - hSrc + 1;
+		xSrc = (dataLen / scanLen) - temp - wSrc + 1;
+		goto anchor_setup;
+	}
+
+	/* Was rotated 180 degrees clockwise. */
+	if (trans == SJME_SCRITCHUI_TRANS_ROT180)
+	{
+		xSrc = scanLen - xSrc - wSrc + 1;
+		ySrc = (dataLen / scanLen) - ySrc - hSrc + 1;
+		goto anchor_setup;
+	}
+
+	/* Was rotated 270 degrees clockwise */
+	if(trans == SJME_SCRITCHUI_TRANS_ROT270)
+	{
+		temp = ySrc;
+		ySrc = scanLen - xSrc - hSrc + 1;
+		xSrc = temp;
+		goto anchor_setup;
+	}
+
+	/* Was mirrored horizontally and rotated 270 degrees clockwise */
+	if(trans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
+	{
+		temp = xSrc;
+		xSrc = ySrc;
+		ySrc = temp;
+	}
+
+anchor_setup:
 	
 	/* Anchor to target coordinates after scaling, because we need */
 	/* to know what our target scale is. */
@@ -179,19 +268,17 @@ sjme_errorCode sjme_scritchpen_core_drawXRGB32Region(
 	
 	/* Get clipping information. */
 	clipLine = &g->state.clipLine;
-	
+
 	/* Clip left X and top Y. */
-	sjme_scritchpen_core_clipLeftTop(g->width, clipLine->s.x,
-		&xSrc, &xDest, &m.tw);
-	sjme_scritchpen_core_clipLeftTop(g->height, clipLine->s.y,
-		&ySrc, &yDest, &m.th);
+	sjme_scritchpen_core_clipLeftTop(clipLine->s.x, &xSrc, &xDest, &m.tw);
+	sjme_scritchpen_core_clipLeftTop(clipLine->s.y, &ySrc, &yDest, &m.th);
 	
 	/* Clip right X and bottom Y. */
 	sjme_scritchpen_core_clipRightBottom(g->width, clipLine->e.x,
 		&xSrc, &xDest, &m.tw);
 	sjme_scritchpen_core_clipRightBottom(g->height, clipLine->e.y,
 		&ySrc, &yDest, &m.th);
-	
+
 	/* Not actually drawing anything? */
 	if (m.tw <= 0 || m.th <= 0)
 		goto skip_noDraw;

--- a/nanocoat/lib/scritchui/scritchPencilRasterMisc.c
+++ b/nanocoat/lib/scritchui/scritchPencilRasterMisc.c
@@ -371,7 +371,6 @@ sjme_errorCode sjme_scritchpen_coreUtil_applyRotateScale(
 {
 	sjme_scritchui_pencilMatrix result;
 	sjme_fixed scaleX, scaleY, temp;
-	sjme_jint xform;
 	
 	if (outMatrix == NULL)
 		return SJME_ERROR_NULL_ARGUMENTS;
@@ -383,57 +382,113 @@ sjme_errorCode sjme_scritchpen_coreUtil_applyRotateScale(
 	scaleX = sjme_fixed_fraction(wSrc, wDest);
 	scaleY = sjme_fixed_fraction(hSrc, hDest);
 	
-	/* This is simple enough to calculate, is just the destination. */
-	result.tw = wDest;
-	result.th = hDest;
-	
-	/* Determine the transformation functions to use. There are just three */
-	/* primitive transformation functions: flip horizontally, then */
-	/* flip vertically, then rotate 90 degrees clockwise. This handles */
-	/* every transformation which fill every single bit. */
-	switch (inTrans)
+	/**
+	 * This is simple enough to calculate, it's just the destination but with
+	 * its width and height swapped if we're handling any 90 or 270 transform
+	 * variation.
+	 */
+	if(inTrans == SJME_SCRITCHUI_TRANS_ROT90 ||
+		inTrans == SJME_SCRITCHUI_TRANS_ROT270 ||
+		inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90 ||
+		inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
 	{
-		/* These bits represent the stuff to do! == 0b9VH; */
-		case SJME_SCRITCHUI_TRANS_NONE:				xform = 0; break;
-		case SJME_SCRITCHUI_TRANS_MIRROR:			xform = 1; break;
-		case SJME_SCRITCHUI_TRANS_MIRROR_ROT180:	xform = 2; break;
-		case SJME_SCRITCHUI_TRANS_ROT180:			xform = 3; break;
-		case SJME_SCRITCHUI_TRANS_ROT90:			xform = 4; break;
-		case SJME_SCRITCHUI_TRANS_MIRROR_ROT90:		xform = 5; break;
-		case SJME_SCRITCHUI_TRANS_MIRROR_ROT270:	xform = 6; break;
-		case SJME_SCRITCHUI_TRANS_ROT270:			xform = 7; break;
-		/* These bits represent the stuff to do! == 0b9VH; */
-
-		default:
-			return sjme_error_notImplemented(0);
+		result.tw = hDest;
+		result.th = wDest;
 	}
+	else
+	{
+		result.tw = wDest;
+		result.th = hDest;
+	}
+
+	/**
+	 * Determine the transformation function to use.
+	 *
+	 * Once a case is matched, the transformation is done and the code skips
+	 * directly to applying it to the output, saving unnecessary if checks,
+	 * especially for the more common cases like TRANS_MIRROR.
+	 */
 	
 	/* Start with this. */
 	result.x.wx = scaleX;
 	result.y.zy = scaleY;
 	
 	/* Mirror horizontally? */
-	if ((xform & 1) != 0)
+	if (inTrans == SJME_SCRITCHUI_TRANS_MIRROR)
+	{
 		result.x.wx = -result.x.wx;
-		
+		goto send_to_out;
+	}
+
 	/* Mirror vertically? */
-	if ((xform & 2) != 0)
+	if (inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT180)
+	{
 		result.y.zy = -result.y.zy;
-		
+		goto send_to_out;
+	}
+
 	/* Rotate 90 degrees clockwise */
 	/* Thanks to jercos for helping out with the matrix math! */
 	/* The math here has been simplified to remove constants and otherwise. */
-	if ((xform & 4) != 0)
+	if (inTrans == SJME_SCRITCHUI_TRANS_ROT90)
 	{
 		temp = result.x.wx;
 		result.x.wx = result.x.zy;
 		result.x.zy = -temp;
-		
+
 		temp = result.y.wx;
 		result.y.wx = result.y.zy;
 		result.y.zy = -temp;
+		goto send_to_out;
 	}
-	
+
+	/* Mirror horizontally and rotate 90 degrees clockwise */
+	if(inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90)
+	{
+		temp = result.x.wx;
+		result.x.wx = -result.x.zy;
+		result.x.zy = -temp;
+
+		temp = result.y.wx;
+		result.y.wx = -result.y.zy;
+		result.y.zy = -temp;
+		goto send_to_out;
+	}
+
+	/* Rotate 180 degrees clockwise. Essentially a hor + vert mirror. */
+	if (inTrans == SJME_SCRITCHUI_TRANS_ROT180)
+	{
+		result.x.wx = -result.x.wx;
+		result.y.zy = -result.y.zy;
+		goto send_to_out;
+	}
+
+	/* Rotate 270 degrees clockwise (A.K.A. 90 degrees counter-clockwise). */
+	if(inTrans == SJME_SCRITCHUI_TRANS_ROT270)
+	{
+		temp = result.x.wx;
+		result.x.wx = -result.x.zy;
+		result.x.zy = temp;
+
+		temp = result.y.wx;
+		result.y.wx = -result.y.zy;
+		result.y.zy = temp;
+		goto send_to_out;
+	}
+
+	/* Mirror horizontally and rotate 270 degrees clockwise */
+	if(inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
+	{
+		temp = result.x.wx;
+		result.x.wx = result.x.zy;
+		result.x.zy = temp;
+
+		temp = result.y.wx;
+		result.y.wx = result.y.zy;
+		result.y.zy = temp;
+	}
+
+send_to_out:
 	/* Success! */
 	memmove(outMatrix, &result, sizeof(result));
 	return SJME_ERROR_NONE;

--- a/nanocoat/lib/scritchui/scritchPencilRasterMisc.c
+++ b/nanocoat/lib/scritchui/scritchPencilRasterMisc.c
@@ -361,6 +361,97 @@ sjme_errorCode sjme_scritchpen_coreUtil_applyAnchor(
 	return SJME_ERROR_NONE;
 }
 
+sjme_errorCode sjme_scritchpen_coreUtil_applyCoordinateAdj(
+	sjme_attrInValue sjme_scritchui_pencilTranslate inTrans,
+	sjme_attrInValue sjme_jint* x,
+	sjme_attrInValue sjme_jint* y,
+	sjme_attrInPositive sjme_jint* w,
+	sjme_attrInPositive sjme_jint* h,
+	sjme_attrInPositive sjme_jint dataWidth,
+	sjme_attrInPositive sjme_jint dataHeight)
+{
+	sjme_jint temp, xform;
+	
+	if (x == NULL || y == NULL || w == NULL || h == NULL)
+		return SJME_ERROR_NULL_ARGUMENTS;
+
+	/* Determine the transformation function to use. */
+	switch (inTrans)
+	{
+		/* These bits represent the stuff to do! == 0b9VH; */
+		case SJME_SCRITCHUI_TRANS_NONE:				xform = 0; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR:			xform = 1; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR_ROT180:	xform = 2; break;
+		/* TRANS_ROT180 is basically a mix of the two above */
+		case SJME_SCRITCHUI_TRANS_ROT180:			xform = 3; break;
+		case SJME_SCRITCHUI_TRANS_ROT90:			xform = 4; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR_ROT90:		xform = 8; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR_ROT270:	xform = 16; break;
+		case SJME_SCRITCHUI_TRANS_ROT270:			xform = 32; break;
+		/* These bits represent the stuff to do! == 0b9VH; */
+
+		default:
+			return sjme_error_notImplemented(0);
+	}
+	
+	/**
+	 * Whenever we receive a transformation that alters the width and height
+	 * the image, the first adjustment we have to do is update the source and
+	 * destination width/height accordingly (makes source/dest width and height
+	 * usage more consistent on further adjustments and clipping).
+	 */
+	if(xform & 4 || xform & 8 || xform & 16 || xform & 32)
+	{
+		temp = *h;
+		*h = *w;
+		*w = temp;
+	}
+
+	/* Mirrored horizontally */
+	if (xform & 1)
+		*x = dataWidth - *x - *w + 1;
+
+	/* Mirrored vertically */
+	if (xform & 2)
+		*y = dataHeight - *y - *h + 1;
+	
+
+	/* Was rotated 90 degrees clockwise. */
+	if (xform & 4)
+	{
+		temp = *x;
+		*x = dataHeight - *y - *w + 1;
+		*y = temp;
+	}
+
+	/* Was mirrored horizontally and rotated 90 degrees clockwise.*/
+	if(xform & 8)
+	{
+		temp = *y;
+		*y = dataWidth - *x - *h + 1;
+		*x = dataHeight - temp - *w + 1;
+	}
+
+	/* Was mirrored horizontally and rotated 270 degrees clockwise */
+	if(xform & 16)
+	{
+		temp = *x;
+		*x = *y;
+		*y = temp;
+	}
+
+	/* Was rotated 270 degrees clockwise */
+	if(xform & 32)
+	{
+		temp = *y;
+		*y = dataWidth - *x - *h + 1;
+		*x = temp;
+	}
+
+	/* Success! */
+	return SJME_ERROR_NONE;
+}
+
 sjme_errorCode sjme_scritchpen_coreUtil_applyRotateScale(
 	sjme_attrOutNotNull sjme_scritchui_pencilMatrix* outMatrix,
 	sjme_attrInValue sjme_scritchui_pencilTranslate inTrans,
@@ -369,128 +460,109 @@ sjme_errorCode sjme_scritchpen_coreUtil_applyRotateScale(
 	sjme_attrInPositive sjme_jint wDest,
 	sjme_attrInPositive sjme_jint hDest)
 {
-	sjme_scritchui_pencilMatrix result;
-	sjme_fixed scaleX, scaleY, temp;
+	sjme_jint temp, xform;
 	
 	if (outMatrix == NULL)
 		return SJME_ERROR_NULL_ARGUMENTS;
-	
-	/* Initialize. */
-	memset(&result, 0, sizeof(result));
-	
-	/* Perform total image scaling first. */
-	scaleX = sjme_fixed_fraction(wSrc, wDest);
-	scaleY = sjme_fixed_fraction(hSrc, hDest);
-	
+
+	/* Determine the transformation function to use. */
+	switch (inTrans)
+	{
+		/* These bits represent the stuff to do! == 0b9VH; */
+		case SJME_SCRITCHUI_TRANS_NONE:				xform = 0; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR:			xform = 1; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR_ROT180:	xform = 2; break;
+		/* TRANS_ROT180 is basically a mix of the two above */
+		case SJME_SCRITCHUI_TRANS_ROT180:			xform = 3; break;
+		case SJME_SCRITCHUI_TRANS_ROT90:			xform = 4; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR_ROT90:		xform = 8; break;
+		case SJME_SCRITCHUI_TRANS_MIRROR_ROT270:	xform = 16; break;
+		case SJME_SCRITCHUI_TRANS_ROT270:			xform = 32; break;
+		/* These bits represent the stuff to do! == 0b9VH; */
+
+		default:
+			return sjme_error_notImplemented(0);
+	}
+
 	/**
 	 * This is simple enough to calculate, it's just the destination but with
 	 * its width and height swapped if we're handling any 90 or 270 transform
 	 * variation.
 	 */
-	if(inTrans == SJME_SCRITCHUI_TRANS_ROT90 ||
-		inTrans == SJME_SCRITCHUI_TRANS_ROT270 ||
-		inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90 ||
-		inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
+	if(xform & 4 || xform & 8 || xform & 16 || xform & 32)
 	{
-		result.tw = hDest;
-		result.th = wDest;
+		outMatrix->tw = hDest;
+		outMatrix->th = wDest;
 	}
 	else
 	{
-		result.tw = wDest;
-		result.th = hDest;
+		outMatrix->tw = wDest;
+		outMatrix->th = hDest;
 	}
-
-	/**
-	 * Determine the transformation function to use.
-	 *
-	 * Once a case is matched, the transformation is done and the code skips
-	 * directly to applying it to the output, saving unnecessary if checks,
-	 * especially for the more common cases like TRANS_MIRROR.
-	 */
 	
-	/* Start with this. */
-	result.x.wx = scaleX;
-	result.y.zy = scaleY;
+	/* Base the matrix x, y step calculations from the scaling values. */
+	outMatrix->x.wx = sjme_fixed_fraction(wSrc, wDest);
+	outMatrix->y.zy = sjme_fixed_fraction(hSrc, hDest);
 	
 	/* Mirror horizontally? */
-	if (inTrans == SJME_SCRITCHUI_TRANS_MIRROR)
-	{
-		result.x.wx = -result.x.wx;
-		goto send_to_out;
-	}
+	if (xform & 1)
+		outMatrix->x.wx = -outMatrix->x.wx;
 
 	/* Mirror vertically? */
-	if (inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT180)
-	{
-		result.y.zy = -result.y.zy;
-		goto send_to_out;
-	}
+	if (xform & 2)
+		outMatrix->y.zy = -outMatrix->y.zy;
 
 	/* Rotate 90 degrees clockwise */
 	/* Thanks to jercos for helping out with the matrix math! */
 	/* The math here has been simplified to remove constants and otherwise. */
-	if (inTrans == SJME_SCRITCHUI_TRANS_ROT90)
+	if (xform & 4)
 	{
-		temp = result.x.wx;
-		result.x.wx = result.x.zy;
-		result.x.zy = -temp;
+		temp = outMatrix->x.wx;
+		outMatrix->x.wx = outMatrix->x.zy;
+		outMatrix->x.zy = -temp;
 
-		temp = result.y.wx;
-		result.y.wx = result.y.zy;
-		result.y.zy = -temp;
-		goto send_to_out;
+		temp = outMatrix->y.wx;
+		outMatrix->y.wx = outMatrix->y.zy;
+		outMatrix->y.zy = -temp;
 	}
 
 	/* Mirror horizontally and rotate 90 degrees clockwise */
-	if(inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT90)
+	if(xform & 8)
 	{
-		temp = result.x.wx;
-		result.x.wx = -result.x.zy;
-		result.x.zy = -temp;
+		temp = outMatrix->x.wx;
+		outMatrix->x.wx = -outMatrix->x.zy;
+		outMatrix->x.zy = -temp;
 
-		temp = result.y.wx;
-		result.y.wx = -result.y.zy;
-		result.y.zy = -temp;
-		goto send_to_out;
-	}
-
-	/* Rotate 180 degrees clockwise. Essentially a hor + vert mirror. */
-	if (inTrans == SJME_SCRITCHUI_TRANS_ROT180)
-	{
-		result.x.wx = -result.x.wx;
-		result.y.zy = -result.y.zy;
-		goto send_to_out;
-	}
-
-	/* Rotate 270 degrees clockwise (A.K.A. 90 degrees counter-clockwise). */
-	if(inTrans == SJME_SCRITCHUI_TRANS_ROT270)
-	{
-		temp = result.x.wx;
-		result.x.wx = -result.x.zy;
-		result.x.zy = temp;
-
-		temp = result.y.wx;
-		result.y.wx = -result.y.zy;
-		result.y.zy = temp;
-		goto send_to_out;
+		temp = outMatrix->y.wx;
+		outMatrix->y.wx = -outMatrix->y.zy;
+		outMatrix->y.zy = -temp;
 	}
 
 	/* Mirror horizontally and rotate 270 degrees clockwise */
-	if(inTrans == SJME_SCRITCHUI_TRANS_MIRROR_ROT270)
+	if(xform & 16)
 	{
-		temp = result.x.wx;
-		result.x.wx = result.x.zy;
-		result.x.zy = temp;
+		temp = outMatrix->x.wx;
+		outMatrix->x.wx = outMatrix->x.zy;
+		outMatrix->x.zy = temp;
 
-		temp = result.y.wx;
-		result.y.wx = result.y.zy;
-		result.y.zy = temp;
+		temp = outMatrix->y.wx;
+		outMatrix->y.wx = outMatrix->y.zy;
+		outMatrix->y.zy = temp;
 	}
 
-send_to_out:
+	/* Rotate 270 degrees clockwise (A.K.A. 90 degrees counter-clockwise). */
+	if(xform & 32)
+	{
+		temp = outMatrix->x.wx;
+		outMatrix->x.wx = -outMatrix->x.zy;
+		outMatrix->x.zy = temp;
+
+		temp = outMatrix->y.wx;
+		outMatrix->y.wx = -outMatrix->y.zy;
+		outMatrix->y.zy = temp;
+	}
+
 	/* Success! */
-	memmove(outMatrix, &result, sizeof(result));
 	return SJME_ERROR_NONE;
 }
 


### PR DESCRIPTION
Previously those were broken due to certain transforms not being processed at all, or under the assumption they'd reach the same result as another (was seemingly the case for ROT_180 and TRANS_MIRROR_ROT180). Furthermore, after those transforms were processed, even if the matrix transforms themselves were correct, the end result would still be incorrect on screen due to the source/destination positions and sizes not being updated to reflect the transformed data.

This commit fixes that, all transforms seem to be done properly now, in all cases known, passing the internal image tests as well as games such as CastleVania: Dawn of Sorrow (K800i version) and Sonic 2 Crash (also for K800i), both of which, together, use all the available transforms with a myriad of clipping and image width/heights.

Do note that Sonic 2 Crash will not yet boot at the current tree state due to SquirrelJME missing Nokia DirectGraphics' implementations as well as fillArc and fillRoundRect, those will be coming soon.

```
You grant Stephanie Gawroriski an irrevocable license that:

 1. That you own the contributing work.
 2. Grants a patent license, as per the GNU GPLv3.
 3. Granting Stephanie Gawroriski permission to redistribute, sell, lease,
    modify, transform, translate, and relicense the specified works. This
    is to simplify the licensing of the project and permit it to be
    consistent. Your contribution may be commercially licensed to other
    parties supporting the project through this means.
 4. If employed by a company, you have a right by that company to provide
    contributions to this project.
 5. Have pledged to follow the Code of Conduct.
 6. Have read and understand the Ettiquite.
```

 * I accept the contributor agreement.

 * I accept that SquirrelJME uses Fossil for its source control
   management and I do understand that my pull request will be merged
   via patch in Fossil instead of via GitHub.
