### PR TITLE
scritchPencilRasterChunky: Implement copyArea.

### DIFF
--- a/emulators/emulator-base-native/c/mle_pencil.c
+++ b/emulators/emulator-base-native/c/mle_pencil.c
@@ -106,7 +106,10 @@ JNIEXPORT void JNICALL FORWARD_FUNC_NAME(PencilShelf, hardwareCopyArea)
 		return;
 	}
 
-	sjme_todo("Impl?");
+	/* Forward. */
+	if (sjme_error_is(error = p->api->copyArea(p, sx, sy, w, h, dw, dh,
+		anchor)))
+		sjme_jni_throwMLECallError(env, error);
 }
 
 JNIEXPORT void JNICALL FORWARD_FUNC_NAME(PencilShelf, hardwareDrawChars)

--- a/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
+++ b/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
@@ -86,6 +86,7 @@ sjme_errorCode sjme_scritchpen_core_copyArea(
 	sjme_errorCode error;
 	sjme_jint tmpSx, tmpSy, scanlineSize;
 	sjme_cpointer copiedArea;
+	sjme_jint y;
 	
 	if (g == NULL)
 		return SJME_ERROR_NULL_ARGUMENTS;
@@ -93,6 +94,25 @@ sjme_errorCode sjme_scritchpen_core_copyArea(
 	/* The source rectangle must always be in bounds. */
 	if (sx < 0 || sx < 0 || sx + w > g->width || sy + h > g->height)
 		return SJME_ERROR_INDEX_OUT_OF_BOUNDS;
+
+	/**
+	 * The destination area on the other hand, can extend beyond the context
+	 * bounds, we just don't copy whatever's outside.
+	 */
+	if (dx < 0)
+	{
+		w += dx;
+		dx = 0;
+	}
+	if (dy < 0)
+	{
+		h += dy;
+		dy = 0;
+	}
+	if(dx + w > g->width)
+		w = g->width - dx;
+	if(dy + h > g->height)
+		h = g->height - dy;
 
 	/* Drawing nothing? */
 	if (w <= 0 || h <= 0)
@@ -117,7 +137,7 @@ sjme_errorCode sjme_scritchpen_core_copyArea(
 	 * image. We can get away with just figuring out the native image format,
 	 * and then go straight to copying from there.
 	 */
-	scanlineSize = (w * g->bitsPerPixel) / 8;
+	g->util->pfScanBytes(g, g->pixelFormat, w, -1, &scanlineSize, NULL);
 	copiedArea = sjme_alloca(scanlineSize * h);
 	if (copiedArea == NULL)
 		return sjme_error_defaultOr(error,
@@ -125,11 +145,9 @@ sjme_errorCode sjme_scritchpen_core_copyArea(
 	
 	memset(copiedArea, 0, scanlineSize * h);
 
-	for(int y = 0; y < h; y++)
-	{
+	for(y = 0; y < h; y++)
 		error |= g->prim.rawScanGet(g, sx, sy + y,
-			(copiedArea + y * scanlineSize), scanlineSize, w);
-	}
+			(copiedArea + (y * scanlineSize)), scanlineSize, w);
 
 	sjme_scritchpen_coreUtil_applyTranslate(g, &tmpSx, &tmpSy);
 
@@ -142,38 +160,13 @@ sjme_errorCode sjme_scritchpen_core_copyArea(
 	sjme_scritchpen_coreUtil_applyTranslate(g, &dx, &dy);
 
 	/**
-	 * The destination area on the other hand, can extend beyond the context
-	 * bounds, we just don't copy whatever's outside.
-	 */
-	if (dx < 0)
-	{
-		w += dx;
-		dx = 0;
-	}
-	if (dy < 0)
-	{
-		h += dy;
-		dy = 0;
-	}
-	if(dx + w > g->width)
-		w = g->width - dx;
-	if(dy + h > g->height)
-		h = g->height - dy;
-
-	/* Drawing nothing? */
-	if (w <= 0 || h <= 0)
-		goto nodraw;
-
-	/**
 	 * Copy the source region into the destination. Note that copyArea is only
 	 * used for mutable images, which only contain opaque pixels as per MIDP 2.
 	 * Thus, no alpha handling is needed.
 	 */
-	for(int y = 0; y < h; y++)
-	{
+	for(y = 0; y < h; y++)
 		error |= g->prim.rawScanPutPure(g, dx, dy + y,
-			(copiedArea + y * scanlineSize), scanlineSize, w);
-	}
+			(copiedArea + (y * scanlineSize)), scanlineSize, w);
 
 nodraw:
 	sjme_alloca_free(copiedArea);

--- a/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
+++ b/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
@@ -84,22 +84,111 @@ sjme_errorCode sjme_scritchpen_core_copyArea(
 	sjme_attrInValue sjme_jint anchor)
 {
 	sjme_errorCode error;
+	sjme_jint tmpSx, tmpSy, scanlineSize;
+	sjme_cpointer copiedArea;
 	
 	if (g == NULL)
 		return SJME_ERROR_NULL_ARGUMENTS;
+
+	/* The source rectangle must always be in bounds. */
+	if (sx < 0 || sx < 0 || sx + w > g->width || sy + h > g->height)
+		return SJME_ERROR_INDEX_OUT_OF_BOUNDS;
+
+	/* Drawing nothing? */
+	if (w <= 0 || h <= 0)
+		return SJME_ERROR_NONE;
 	
 	/* Need to lock? */
 	if (sjme_error_is(error = sjme_scritchpen_core_lock(g)))
 		return sjme_error_default(error);
 	
-	sjme_todo("Impl?");
-	return sjme_error_notImplemented(0);
+	error = SJME_ERROR_NONE;
+
+	/* Those are needed to translate back before moving to the dest area. */
+	tmpSx = -sx;
+	tmpSy = -sy;
+
+	/* Translate base coordinates. */
+	sjme_scritchpen_coreUtil_applyTranslate(g, &sx, &sy);
+
+	/**
+	 * A neat property here is that we don't need to worry about format
+	 * conversion, as the data is being copied between regions of the same
+	 * image. We can get away with just figuring out the native image format,
+	 * and then go straight to copying from there.
+	 */
+	scanlineSize = (w * g->bitsPerPixel) / 8;
+	copiedArea = sjme_alloca(scanlineSize * h);
+	if (copiedArea == NULL)
+		return sjme_error_defaultOr(error,
+			sjme_error_outOfMemory(NULL, scanlineSize * h));
 	
+	memset(copiedArea, 0, scanlineSize * h);
+
+	for(int y = 0; y < h; y++)
+	{
+		error |= g->prim.rawScanGet(g, sx, sy + y,
+			(copiedArea + y * scanlineSize), scanlineSize, w);
+	}
+
+	sjme_scritchpen_coreUtil_applyTranslate(g, &tmpSx, &tmpSy);
+
+	/* Now start moving to the destination in order to copy into it. */
+
+	/* Apply anchor to the destination area. */
+	error = sjme_scritchpen_coreUtil_applyAnchor(anchor, dx, dy, w, h, 0, &dx,
+		&dy);
+
+	sjme_scritchpen_coreUtil_applyTranslate(g, &dx, &dy);
+
+	/**
+	 * The destination area on the other hand, can extend beyond the context
+	 * bounds, we just don't copy whatever's outside.
+	 */
+	if (dx < 0)
+	{
+		w += dx;
+		dx = 0;
+	}
+	if (dy < 0)
+	{
+		h += dy;
+		dy = 0;
+	}
+	if(dx + w > g->width)
+		w = g->width - dx;
+	if(dy + h > g->height)
+		h = g->height - dy;
+
+	/* Drawing nothing? */
+	if (w <= 0 || h <= 0)
+		goto nodraw;
+
+	/**
+	 * Copy the source region into the destination. Note that copyArea is only
+	 * used for mutable images, which only contain opaque pixels as per MIDP 2.
+	 * Thus, no alpha handling is needed.
+	 */
+	for(int y = 0; y < h; y++)
+	{
+		error |= g->prim.rawScanPutPure(g, dx, dy + y,
+			(copiedArea + y * scanlineSize), scanlineSize, w);
+	}
+
+nodraw:
+	sjme_alloca_free(copiedArea);
+
+	/* Failed? */
+	if (sjme_error_is(error))
+		goto fail_any;
+
 	/* Release lock. */
 	if (sjme_error_is(error = sjme_scritchpen_core_lockRelease(g)))
 		return sjme_error_default(error);
-	return sjme_error_notImplemented(0);
-	
+
+	/* Success! */
+	return SJME_ERROR_NONE;
+
 fail_any:
 	/* Need to release the lock? */
 	if (sjme_error_is(sjme_scritchpen_core_lockRelease(g)))


### PR DESCRIPTION
Another one of the core MIDP 2+ rendering operations. Is used extensively by some games like Gameloft's Ninja Prophecy, where the entire background is built using copyArea calls.

```
You grant Stephanie Gawroriski an irrevocable license that:

 1. That you own the contributing work.
 2. Grants a patent license, as per the GNU GPLv3.
 3. Granting Stephanie Gawroriski permission to redistribute, sell, lease,
    modify, transform, translate, and relicense the specified works. This
    is to simplify the licensing of the project and permit it to be
    consistent. Your contribution may be commercially licensed to other
    parties supporting the project through this means.
 4. If employed by a company, you have a right by that company to provide
    contributions to this project.
 5. Have pledged to follow the Code of Conduct.
 6. Have read and understand the Ettiquite.
```

 * I accept the contributor agreement.

 * I accept that SquirrelJME uses Fossil for its source control
   management and I do understand that my pull request will be merged
   via patch in Fossil instead of via GitHub.
