### PR TITLE
scritchui: Fix some memory leaks on GTK2.

### DIFF
--- a/nanocoat/lib/scritchui/gtk2/gtk2Pencil.c
+++ b/nanocoat/lib/scritchui/gtk2/gtk2Pencil.c
@@ -90,6 +90,9 @@ static sjme_errorCode sjme_scritchui_gtk2_pencilRawScanGet(
 	rawPix = gdk_pixbuf_get_pixels(pix);
 	if (rawPix != NULL)
 		memmove(outData, rawPix, inDataLen);
+
+	/* Cleanup */
+	g_object_unref(pix);
 	
 	/* Success! */
 	return SJME_ERROR_NONE;
@@ -126,6 +129,9 @@ static sjme_errorCode sjme_scritchui_gtk2_pencilRawScanPutPure(
 	gdk_pixbuf_render_to_drawable(pix, drawable, gc,
 		0, 0, x, y, srcNumPixels, 1,
 		GDK_RGB_DITHER_NONE, 0, 0);
+
+	/* Cleanup */
+	g_object_unref(pix);
 	
 	/* Success! */
 	return SJME_ERROR_NONE;

--- a/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
+++ b/nanocoat/lib/scritchui/scritchPencilRasterChunky.c
@@ -361,6 +361,9 @@ sjme_errorCode sjme_scritchpen_core_drawXRGB32Region(
 			srcAlpha, mulAlpha, mulAlphaVal)))
 			goto fail_anyInLock;
 	}
+
+	/* Cleanup. */
+	sjme_alloca_free(srcRgb);
 	
 	/* Release lock. */
 	if (sjme_error_is(error = sjme_scritchpen_core_lockRelease(g)))


### PR DESCRIPTION
gtk2Pencil was constantly allocating new GdkPixBufs without actually freeing them after serving their purpose, quickly piling up tens of Megabytes of leaked memory every second. I am not sure whether or now Win32 is affected by similar leaks, but anything using the GTK2 pencil, like Linux, certainly was.

This might not be the only instance of memory leaks in SquirrelJME, but even if it wasn't, it was by a long margin the largest one.

drawXRGB32Region also now frees srcRgb explicitly in success cases as well.

```
You grant Stephanie Gawroriski an irrevocable license that:

 1. That you own the contributing work.
 2. Is to your knowledge not encumbered by any patents.
 3. Granting Stephanie Gawroriski permission to redistribute, sell, lease,
    modify, transform, translate, and relicense the specified works. This
    is to simplify the licensing of the project and permit it to be
    consistent. Your contribution may be commercially licensed to other
    parties supporting the project through this means.
 4. If employed by a company, you have a right by that company to provide
    contributions to this project.
 5. Have pledged to follow the Code of Conduct.
 6. Have read and understand the Ettiquite.
 7. Understand that the code will be placed under the MPLv2.
```

 * I accept the contributor agreement.

 * I accept that SquirrelJME uses Fossil for its source control
   management and I do understand that my pull request will be merged
   via patch in Fossil instead of via GitHub.
