### PR TITLE
ci: add a Linux aarch64 build, and fix the 3DS one

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,6 +175,11 @@ libretro-build-linux-x64:
     - .libretro-linux-cmake-x86_64
     - .core-nanocoat
 
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-nanocoat
+
 # ngc-static-cmake.yml
 libretro-build-ngc:
   extends:


### PR DESCRIPTION
Two things, both about the libretro buildbot.

## Linux aarch64

There is no aarch64 build of SquirrelJME, so the core is missing from https://buildbot.libretro.com/nightly/linux/aarch64/latest/ . This mirrors the existing `libretro-build-linux-x64` job. For CMake cores the `.libretro-linux-cmake-aarch64` class already lives inside the `/linux-cmake.yml` template included here, so no extra `include:` entry is needed (same as libretro/swanstation, libretro/arduous).

Verified locally: nanocoat builds natively on aarch64 (glibc toolchain, GCC 15) and produces `squirreljme_libretro.so` as an aarch64 shared object, with no source changes needed. (The unit-test executables in `tests/` fail to link here only because they link statically and static libm was unavailable; the core itself is unaffected.)

## Nintendo 3DS

`libretro-build-ctr` is the only red job in the pipeline. It does not fail while building the core — it reaches `lib/base` and dies on `multithreadPosix.c` with implicit declarations of `pthread_self`, `pthread_equal` and `pthread_create`, because devkitARM's newlib declares `pthread_kill` and little else.

`config.h` already knows this and forces `SJME_CONFIG_ONLY_THREAD_SINGLE` on the 3DS, with a comment saying its pthreads are broken — but that does not unset `SJME_CONFIG_HAS_THREADS_PTHREAD`, which is what `multithreadPosix.c` guards on. And it reaches that point at all because the 3DS is never recognised: the buildbot log says `Detected Target System: unknown/arm32l`, so the `"3ds"` entry in `find-threads.cmake` cannot match.

The comment above that list still reads *"Also consider unknown platforms as unsupported"* while the condition no longer does; `"unknown"` looks to have been dropped when `gamecube`, `wii` and `wiiu` were added. Restoring it is also right on its own terms — a platform whose identity could not be determined is exactly one where nothing is known about its threading.

Verified: an unidentified system now reports `Threads not supported!` and leaves the macro undefined, so `multithreadPosix.c` compiles to nothing; a native configure still reports `PThread: Valid!`. Not verified: a real 3DS build — there is no devkitARM here, so the buildbot will be the judge.

Worth a separate look: why the 3DS comes out as `unknown` at all. The defines the probe dumps contain no 3DS markers and report `__ARM_ARCH_4T__`, which is bare `arm-none-eabi` rather than the 3DS's ARMv6K — the compiler is being asked what it predefines without the flags the toolchain file adds. Fixing that would make the `"3ds"` entry match properly and likely help the other devkitPro targets identify themselves too. Left alone here: different change, and untestable from where I sit.